### PR TITLE
Add Develocity Gradle Plugin support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ java {
 }
 
 dependencies {
+    implementation("com.gradle:develocity-gradle-plugin:3.18.1")
     implementation("com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.1")
     testImplementation("junit:junit:4.13.2")
 }

--- a/src/main/kotlin/io/github/cdsap/ipinfo/InfoKotlinProcessPlugin.kt
+++ b/src/main/kotlin/io/github/cdsap/ipinfo/InfoKotlinProcessPlugin.kt
@@ -19,7 +19,7 @@ class IpInfoPlugin : Plugin<Project> {
             if (develocityConfiguration != null) {
                 buildScanDevelocityReporting(project, develocityConfiguration)
             } else if (enterpriseExtension != null) {
-                buildScanReporting(project, enterpriseExtension)
+                buildScanEnterpriseReporting(project, enterpriseExtension)
             }
         }
     }
@@ -37,7 +37,7 @@ class IpInfoPlugin : Plugin<Project> {
         }
     }
 
-    private fun buildScanReporting(
+    private fun buildScanEnterpriseReporting(
         project: Project,
         buildScanExtension: BuildScanExtension
     ) {

--- a/src/main/kotlin/io/github/cdsap/ipinfo/output/BuildScanOutput.kt
+++ b/src/main/kotlin/io/github/cdsap/ipinfo/output/BuildScanOutput.kt
@@ -9,37 +9,13 @@ class BuildScanOutput(
 ) {
 
     fun addGeolocationInfoToBuildScan() {
-        buildScanExtension.value(
-            "City",
-            ip.city
-        )
-        buildScanExtension.value(
-            "Country",
-            ip.country
-        )
-        buildScanExtension.value(
-            "State",
-            ip.regionName
-        )
-        buildScanExtension.value(
-            "Ip",
-            ip.query
-        )
-        buildScanExtension.value(
-            "Isp",
-            ip.isp
-        )
-        buildScanExtension.value(
-            "Timezone",
-            ip.timeZone
-        )
-        buildScanExtension.value(
-            "Lat",
-            ip.lat
-        )
-        buildScanExtension.value(
-            "Long",
-            ip.long
-        )
+        buildScanExtension.value("City", ip.city)
+        buildScanExtension.value("Country", ip.country)
+        buildScanExtension.value("State", ip.regionName)
+        buildScanExtension.value("Ip", ip.query)
+        buildScanExtension.value("Isp", ip.isp)
+        buildScanExtension.value("Timezone", ip.timeZone)
+        buildScanExtension.value("Lat", ip.lat)
+        buildScanExtension.value("Long", ip.long)
     }
 }

--- a/src/main/kotlin/io/github/cdsap/ipinfo/output/DevelocityValues.kt
+++ b/src/main/kotlin/io/github/cdsap/ipinfo/output/DevelocityValues.kt
@@ -1,0 +1,22 @@
+package io.github.cdsap.ipinfo.output
+
+import com.gradle.develocity.agent.gradle.DevelocityConfiguration
+import io.github.cdsap.ipinfo.model.Ip
+
+class DevelocityValues(
+    private val develocityConfiguration: DevelocityConfiguration,
+    private val ip: Ip
+) {
+    fun addGeolocationInfoToBuildScan() {
+        develocityConfiguration.buildScan {
+            value("City", ip.city)
+            value("Country", ip.country)
+            value("State", ip.regionName)
+            value("Ip", ip.query)
+            value("Isp", ip.isp)
+            value("Timezone", ip.timeZone)
+            value("Lat", ip.lat)
+            value("Long", ip.long)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds Develocity Gradle plugin support to address the following deprecation warnings:
```
- The deprecated "gradleEnterprise.buildScan.buildFinished" API has been replaced by "develocity.buildScan.buildFinished"
- The deprecated "gradleEnterprise.buildScan.value" API has been replaced by "develocity.buildScan.value"
```